### PR TITLE
chore: improve crates.io metadata and add cargo publish to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all
+      - name: Publish to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Improved crates.io metadata: keyword-rich description, `rust-version = "1.88"` MSRV, authors, `documentation` pointing to docs.rs, and `exclude` to reduce published crate size
+- Added `#![doc = include_str!("../README.md")]` to `src/main.rs` so docs.rs renders the README as the crate landing page
+- Release workflow now publishes to crates.io automatically on tag push (requires `CARGO_REGISTRY_TOKEN` secret)
+
 ### Added
 - Custom MiniJinja template filters: `sha256`, `base64_encode`, `base64_decode` available in all templates (render and seed spec files)
 - `sha256` filter with optional `mode` parameter (`"hex"` default, `"bytes"` for byte array output)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,14 +2,17 @@
 name = "initium"
 version = "1.0.4"
 edition = "2021"
-description = "Swiss-army toolbox for Kubernetes initContainers"
+rust-version = "1.88"
+authors = ["Kitstream <opensource@kitstream.io>"]
+description = "Swiss-army toolbox for Kubernetes initContainers — wait-for, migrate, seed, render, fetch in a single static Rust binary"
 license = "Apache-2.0"
 repository = "https://github.com/KitStream/initium"
 homepage = "https://github.com/KitStream/initium"
-documentation = "https://github.com/KitStream/initium/blob/main/docs/usage.md"
+documentation = "https://docs.rs/initium"
 keywords = ["kubernetes", "initcontainer", "sidecar", "container", "devops"]
 categories = ["command-line-utilities", "development-tools"]
 readme = "README.md"
+exclude = ["tests/", "examples/", ".github/", "charts/", "docs/", ".claude/"]
 
 [[bin]]
 name = "initium"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 mod cmd;
 mod duration;
 mod logging;


### PR DESCRIPTION
## Summary

- Enrich `Cargo.toml` description with subcommand keywords (wait-for, migrate, seed, render, fetch) for better crates.io and AI search discoverability
- Add `rust-version = "1.88"` MSRV, `authors`, and `documentation` pointing to docs.rs
- Add `exclude` to reduce published crate size (drops tests, examples, CI, charts, docs from the package)
- Add `#![doc = include_str!("../README.md")]` so docs.rs renders the full README as the crate landing page
- Add `cargo publish` step to the release workflow, running after tests pass and before Docker builds

## Setup required

Add a `CARGO_REGISTRY_TOKEN` repository secret (from https://crates.io/settings/tokens) for the publish step to work.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo test --all-features` — 163 tests pass
- [x] `cargo package --list --allow-dirty` — 32 files, no excluded dirs leak through

🤖 Generated with [Claude Code](https://claude.com/claude-code)