### PR TITLE
fix: address PR #32 review comments on release automation

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -28,7 +28,7 @@ Once confirmed:
 
 1. Fetch origin and create a branch: `release/vX.Y.Z` from `origin/main`.
 2. Bump version in `Cargo.toml` (the `version = "..."` field under `[package]`).
-3. Run `cargo check` to update `Cargo.lock`.
+3. Run `cargo check` to ensure the project builds successfully after the version bump.
 4. Update `CHANGELOG.md`:
    - Move everything under `## [Unreleased]` into a new `## [X.Y.Z] - YYYY-MM-DD` section (use today's date).
    - Leave `## [Unreleased]` empty (with just the heading).

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -12,12 +12,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Check for version bump
         id: version
         run: |
           CURRENT=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
-          PREVIOUS=$(git show HEAD~1:Cargo.toml | grep '^version' | head -1 | sed 's/.*"\(.*\)"/\1/')
+          if [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
+            PREVIOUS="$CURRENT"
+          else
+            PREVIOUS=$(git show ${{ github.event.before }}:Cargo.toml | grep '^version' | head -1 | sed 's/.*"\(.*\)"/\1/')
+          fi
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
           echo "previous=$PREVIOUS" >> "$GITHUB_OUTPUT"
           if [ "$CURRENT" != "$PREVIOUS" ]; then
@@ -30,11 +34,22 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.current }}"
           TAG="v${VERSION}"
+          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q .; then
+            echo "Tag $TAG already exists on origin, skipping"
+            exit 0
+          fi
           if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists, skipping"
+            echo "Tag $TAG already exists locally, skipping"
             exit 0
           fi
           git tag "$TAG"
-          git push origin "$TAG"
+          if ! git push origin "$TAG"; then
+            if git ls-remote --tags origin "refs/tags/$TAG" | grep -q .; then
+              echo "Tag $TAG was created concurrently on origin, skipping"
+              exit 0
+            fi
+            echo "Failed to push tag $TAG"
+            exit 1
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- **Guard null SHA**: When `github.event.before` is the null SHA (first push to main), skip version comparison instead of failing `git show`.
- **Use `github.event.before` SHA** instead of `HEAD~1` for version diff — reliably detects version bumps across multi-commit pushes and merges.
- **Check remote tags via `git ls-remote`** before creating — handles shallow checkouts and concurrent tag creation gracefully.
- **Fix misleading `cargo check` comment** in `/release` skill — it validates the build, not updates `Cargo.lock`.

## Test plan
- [ ] Verify auto-tag workflow YAML is valid
- [ ] Verify `/release` skill wording is accurate
- [ ] Confirm CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)