### PR TITLE
fix: replace --mount=type=cache with dependency layer caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Auto-tag workflow: CI automatically creates a git tag when `Cargo.toml` version changes on main, triggering the release workflow.
 - `/release` skill for Claude Code: guided release preparation with version determination, confirmation, and PR creation.
 
+### Fixed
+- Replaced Dockerfile `--mount=type=cache` with dependency layer caching ("empty main" trick) for reliable Docker build caching in GitHub Actions, where `--mount=type=cache` does not persist across runners.
+
 ## [1.2.0] - 2026-03-11
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@ ARG VERSION=dev
 RUN apk add --no-cache musl-dev openssl-dev openssl-libs-static perl
 WORKDIR /src
 COPY Cargo.toml Cargo.lock ./
-COPY . .
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/src/target \
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && \
     cargo build --release && \
-    cp target/release/initium /initium
+    rm -rf src target/release/deps/initium* target/release/initium*
+COPY . .
+RUN cargo build --release
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /initium /initium
+COPY --from=builder /src/target/release/initium /initium
 USER 65534:65534
 ENTRYPOINT ["/initium"]

--- a/jyq.Dockerfile
+++ b/jyq.Dockerfile
@@ -3,14 +3,14 @@ ARG VERSION=dev
 RUN apk add --no-cache musl-dev openssl-dev openssl-libs-static perl
 WORKDIR /src
 COPY Cargo.toml Cargo.lock ./
-COPY . .
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/src/target \
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && \
     cargo build --release && \
-    cp target/release/initium /initium
+    rm -rf src target/release/deps/initium* target/release/initium*
+COPY . .
+RUN cargo build --release
 FROM alpine:3.21
 RUN apk add --no-cache jq yq ca-certificates \
     && rm -rf /var/cache/apk/*
-COPY --from=builder /initium /initium
+COPY --from=builder /src/target/release/initium /initium
 USER 65534:65534
 ENTRYPOINT ["/initium"]


### PR DESCRIPTION
## Summary
- Replaced `--mount=type=cache` with the "empty main" dependency layer caching trick in both `Dockerfile` and `jyq.Dockerfile`
- `--mount=type=cache` does not persist across GitHub Actions runners, causing full Rust recompilation on every release build
- The dependency layer caching pattern (copy Cargo.toml/lock → build with dummy main.rs → remove initium artifacts → copy real source → rebuild) leverages Docker's built-in layer cache and works reliably with GitHub Actions' `type=gha` cache

## Test plan
- [ ] Verify Docker build succeeds locally: `docker build -t initium .`
- [ ] Verify jyq variant builds: `docker build -f jyq.Dockerfile -t initium-jyq .`
- [ ] Confirm CI passes
- [ ] Verify next release build is faster (dependency layer cached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)